### PR TITLE
Add ADScanPro/adscan to Active Directory audit and exploit tools

### DIFF
--- a/docs/topics/active-directory-audit-and-exploit-tools.md
+++ b/docs/topics/active-directory-audit-and-exploit-tools.md
@@ -25,3 +25,4 @@
 - [GhostPack/PSPKIAudit](https://github.com/GhostPack/PSPKIAudit) - PowerShell toolkit for AD CS auditing based on the PSPKI toolkit.
 - [cfalta/PoshADCS](https://github.com/cfalta/PoshADCS) - A proof of concept on attack vectors against Active Directory by abusing Active Directory Certificate Services (ADCS)
 - [Kevin-Robertson/Sharpmad](https://github.com/Kevin-Robertson/Sharpmad) - C# version of Powermad
+- [ADScanPro/adscan](https://github.com/ADScanPro/adscan) - Active Directory pentesting CLI for Linux: enumeration, Kerberoasting, ADCS/ESC abuse, DCSync, RBCD and attack paths to Domain Admin


### PR DESCRIPTION
Adding [ADScanPro/adscan](https://github.com/ADScanPro/adscan) to `docs/topics/active-directory-audit-and-exploit-tools.md`.

An actively maintained Linux CLI that chains a full AD pentest from one terminal: enumeration, Kerberoasting, AS-REP roasting, ADCS/ESC abuse, DCSync, RBCD, shadow credentials, credential dumping, and attack path analysis to Domain Admin. It complements the single-purpose tools already listed here (Certipy, rbcd-attack, ldapdomaindump) by running the chain end to end.

- 490+ stars, releases roughly weekly
- `pipx install adscan`, Linux only, no Windows host needed
- Free to use; a paid tier covers client reporting

Matched the existing `owner/repo` link-text convention and appended at the end of the list. Disclosure: I maintain the project.